### PR TITLE
exclude 2.x versions of the mongo gem dependency

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version      = '>= 1.9.2'
   gem.requirements               = []
   gem.add_runtime_dependency     'rdf',         '>= 1.1'
-  gem.add_runtime_dependency     'mongo',       '>= 1.8.6'
+  gem.add_runtime_dependency     'mongo',       '>= 1.8.6',    '< 2.0'
 
   gem.add_development_dependency 'rdf-spec',    '>= 1.1'
   gem.add_development_dependency 'rspec',       '>= 2.14.0'


### PR DESCRIPTION
This sets the version range to 1.8.6 - 1.x.x (currently 1.12.3) for the
mongo gem dependency.

Version 2.x.x of the mongo gem was introduced with API incompatibilities
with 1.x.x. The most prominent is when you create an
RDF::Mongo::Repsitory:

    NameError: uninitialized constant Mongo::Connection

Mongo version 2.0.0 replaces Mongo::Connection with Mongo::Client.
The API documentation is here:

    http://api.mongodb.org/ruby

The following terminal capture shows the experience when a 2.x.x version
of the mongo gem dependency is installed.

    https://asciinema.org/a/28790